### PR TITLE
chore: add clippy as optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "tox"
 version = "0.0.1"
 dependencies = [
+ "clippy 0.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "ip 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,6 +16,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clippy"
+version = "0.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quine-mc_cluskey 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -62,6 +75,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +93,11 @@ dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quine-mc_cluskey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
@@ -106,6 +129,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sodiumoxide"
 version = "0.0.9"
 source = "git+https://github.com/dnaq/sodiumoxide.git#a41a89eec3ed8e343d0bbf9c79865c6955f8205d"
@@ -114,6 +145,19 @@ dependencies = [
  "libsodium-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "toml"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ git = "https://github.com/dnaq/sodiumoxide.git"
 [dependencies]
 ip = "1.1"
 log = "0.3"
+clippy = { version = "*", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,9 @@ fn main() {
 
 */
 
+#![cfg_attr(feature="clippy", feature(plugin))]
+
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Clippy is turned off by default. The way to build with clippy lints:

cargo build --features "clippy"

At the moment there is a lot of false positive warnings. They should be reviewed (perhaps, turned off where appropriate).
