### PR TITLE
refactor: parsing with remaining input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 .cargo/
+
+*.swp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ extern crate sodiumoxide;
 */
 #[warn(missing_docs)]
 pub mod toxcore {
+    #[macro_use]
     pub mod binary_io;
     pub mod crypto_core;
     pub mod dht;

--- a/src/toxcore/binary_io.rs
+++ b/src/toxcore/binary_io.rs
@@ -109,6 +109,7 @@ pub trait FromBytes<Output> {
         Ok(Parsed(result, bytes))
     }
     /// De-serialize from bytes, or return `None` if de-serialization failed.
+    /// Note: it returns Some even if there are remaining bytes left.
     fn from_bytes(bytes: &[u8]) -> Option<Output> {
         match Self::parse_bytes(bytes) {
             Ok(Parsed(value, _)) => Some(value),

--- a/src/toxcore/binary_io.rs
+++ b/src/toxcore/binary_io.rs
@@ -26,10 +26,98 @@ pub trait ToBytes {
     fn to_bytes(&self) -> Vec<u8>;
 }
 
+/// Parsing result. Provides result and remaining input. 
+pub struct Parsed<'a, Output>(
+    /// Result.
+    pub Output,
+    /// Remaining input.
+    pub &'a [u8]
+);
+
+/// Parsing error.
+#[derive(Debug)]
+pub struct ParseError{
+    target: &'static str,
+    message: String,
+    file: &'static str,
+    line: u32
+}
+
+impl ParseError {
+    /// Create new ParseError
+    pub fn new(target: &'static str, message: String,
+           file: &'static str, line: u32) -> ParseError {
+        ParseError{
+            target: target,
+            message: message,
+            file: file,
+            line: line
+        }
+    }
+}
+
+macro_rules! parse_error {
+    (target: $target:expr, $($arg:tt)*) => (
+        Err(ParseError::new(
+                $target,
+                format!($($arg)*),
+                file!(),
+                line!()))
+    );
+    ($($arg:tt)*) => (parse_error!(target: module_path!(), $($arg)*))
+}
+
+/// Result type for parsing methods
+pub type ParseResult<'a, Output> = Result<Parsed<'a, Output>, ParseError>;
+
 /// De-serialize from bytes, or return `None` if de-serialization failed.
 pub trait FromBytes<Output> {
+
+    /// De-serialize from bytes.
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Output>;
+
+    /// De-serialize exact `times` entities from bytes.
+    fn parse_bytes_multiple_n(times: usize, bytes: &[u8]) -> ParseResult<Vec<Output>> {
+        debug!("De-serializing multiple ({}) outputs.", times);
+        trace!("With bytes: {:?}", bytes);
+
+        let mut bytes = bytes;
+        let mut result = Vec::with_capacity(times);
+
+        for _ in 0..times {
+            let Parsed(value, rest) = try!(Self::parse_bytes(bytes));
+            bytes = rest;
+            result.push(value);
+        }
+
+        Ok(Parsed(result, bytes))
+    }
+
+    /// De-serialize as many entities from bytes as posible.
+    fn parse_bytes_multiple(bytes: &[u8]) -> ParseResult<Vec<Output>> {
+        debug!("De-serializing multiple outputs.");
+        trace!("With bytes: {:?}", bytes);
+
+        let mut bytes = bytes;
+        let mut result = Vec::new();
+
+        while let Ok(Parsed(value, rest)) = Self::parse_bytes(bytes) {
+            bytes = rest;
+            result.push(value);
+        }
+
+        Ok(Parsed(result, bytes))
+    }
     /// De-serialize from bytes, or return `None` if de-serialization failed.
-    fn from_bytes(bytes: &[u8]) -> Option<Output>;
+    fn from_bytes(bytes: &[u8]) -> Option<Output> {
+        match Self::parse_bytes(bytes) {
+            Ok(Parsed(value, _)) => Some(value),
+            Err(err) => {
+                debug!("Can't parse bytes. Error: {:?}", err);
+                None
+            }
+        }
+    }
 }
 
 

--- a/src/toxcore/dht.rs
+++ b/src/toxcore/dht.rs
@@ -554,7 +554,7 @@ impl FromBytes<GetNodes> for GetNodes {
             let b = &bytes[PUBLICKEYBYTES..GET_NODES_SIZE];
             let id = array_to_u64(&[b[0], b[1], b[2], b[3],
                                     b[4], b[5], b[6], b[7]]);
-            Ok(Parsed(GetNodes { pk: pk, id: id }, &bytes[PUBLICKEYBYTES..]))
+            Ok(Parsed(GetNodes { pk: pk, id: id }, &bytes[GET_NODES_SIZE..]))
         } else {
             return parse_error!("Failed to de-serialize bytes into GetNodes!")
         }
@@ -898,7 +898,9 @@ impl FromBytes<DhtPacket> for DhtPacket {
         let sender_pk = match PublicKey::from_slice(&bytes[..PUBLICKEYBYTES]) {
             Some(pk) => pk,
             None => {
-                return parse_error!("Failed; de-serializing sender's PK! With bytes for PK: {:?}", &bytes[..PUBLICKEYBYTES])
+                return parse_error!("Failed; de-serializing sender's PK! \
+                                    With bytes for PK: {:?}",
+                                    &bytes[..PUBLICKEYBYTES])
             },
         };
         let bytes = &bytes[PUBLICKEYBYTES..];
@@ -906,7 +908,9 @@ impl FromBytes<DhtPacket> for DhtPacket {
         let nonce = match Nonce::from_slice(&bytes[..NONCEBYTES]) {
             Some(n) => n,
             None => {
-                return parse_error!("Failed; de-serializing nonce! With bytes for nonce: {:?}", &bytes[..NONCEBYTES])
+                return parse_error!("Failed; de-serializing nonce! \
+                                    With bytes for nonce: {:?}",
+                                    &bytes[..NONCEBYTES])
             },
         };
         let bytes = &bytes[NONCEBYTES..];

--- a/src/toxcore/dht.rs
+++ b/src/toxcore/dht.rs
@@ -62,16 +62,13 @@ pub enum PingType {
     doesn't match `PingType` or slice has no elements.
 */
 impl FromBytes<PingType> for PingType {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "PingType", "Creating PingType from bytes.");
         trace!(target: "PingType", "Bytes: {:?}", bytes);
-        match PacketKind::from_bytes(bytes) {
-            Some(PacketKind::PingReq)  => Some(PingType::Req),
-            Some(PacketKind::PingResp) => Some(PingType::Resp),
-            _ => {
-                debug!("Creating PingType from bytes failed!");
-                None
-            },
+        match try!(PacketKind::parse_bytes(bytes)) {
+            Parsed(PacketKind::PingReq, rest)  => Ok(Parsed(PingType::Req, rest)),
+            Parsed(PacketKind::PingResp, rest) => Ok(Parsed(PingType::Resp, rest)),
+            Parsed(value, _) => return parse_error!("Unexpected PacketKind '{:?}'", value)
         }
     }
 }
@@ -169,24 +166,21 @@ impl ToBytes for Ping {
     `Ping`.
 */
 impl FromBytes<Ping> for Ping {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "Ping", "De-serializing Ping from bytes.");
         trace!(target: "Ping", "With bytes: {:?}", bytes);
 
         if bytes.len() < PING_SIZE {
-            debug!("There are less bytes than PING_SIZE!");
-            return None;
+            return parse_error!("There are less bytes than PING_SIZE!")
         }
 
-        if let Some(ping_type) = PingType::from_bytes(bytes) {
-            return Some(Ping {
-                p_type: ping_type,
-                id: array_to_u64(&[bytes[1], bytes[2], bytes[3], bytes[4],
-                                   bytes[5], bytes[6], bytes[7], bytes[8]]),
-            })
-        }
-        debug!("De-serializing Ping failed!");
-        None
+        let Parsed(ping_type, bytes) = try!(PingType::parse_bytes(bytes));
+        
+        Ok(Parsed(Ping {
+            p_type: ping_type,
+            id: array_to_u64(&[bytes[0], bytes[1], bytes[2], bytes[3],
+                               bytes[4], bytes[5], bytes[6], bytes[7]]),
+        }, &bytes[8..]))
     }
 }
 
@@ -224,25 +218,25 @@ pub enum IpType {
 /// Match first byte from the provided slice as `IpType`. If no match found,
 /// return `None`.
 impl FromBytes<IpType> for IpType {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "IpType", "De-serializing IpType from bytes.");
         trace!(target: "IpType", "With bytes: {:?}", bytes);
 
         if bytes.is_empty() {
-            debug!("There are 0 bytes!");
-            return None
+            return parse_error!("There are 0 bytes!")
         }
 
-        match bytes[0] {
-            2   => Some(IpType::U4),
-            10  => Some(IpType::U6),
-            130 => Some(IpType::T4),
-            138 => Some(IpType::T6),
+        let res = match bytes[0] {
+            2   => IpType::U4,
+            10  => IpType::U6,
+            130 => IpType::T4,
+            138 => IpType::T6,
             _   => {
-                debug!("Can't de-serialize bytes into IpType!");
-                None
+                return parse_error!("Can't de-serialize bytes into IpType!")
             },
-        }
+        };
+
+        Ok(Parsed(res, &bytes[1..]))
     }
 }
 
@@ -270,20 +264,19 @@ impl ToBytes for IpAddr {
 /// Can fail if there are less than 16 bytes supplied, otherwise parses first
 /// 16 bytes as an `Ipv6Addr`.
 impl FromBytes<Ipv6Addr> for Ipv6Addr {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "Ipv6Addr", "De-serializing Ipv6Addr from bytes.");
         trace!(target: "Ipv6Addr", "With bytes: {:?}", bytes);
 
         if bytes.len() < 16 {
-            debug!("Not enough bytes for Ipv6Addr!");
-            return None
+            return parse_error!("Not enough bytes for Ipv6Addr!")
         }
 
         let mut v = Vec::with_capacity(8);
         for slice in bytes[..16].chunks(2) {
             v.push(array_to_u16(&[slice[0], slice[1]]));
         }
-        Some(Ipv6Addr::new(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]))
+        Ok(Parsed(Ipv6Addr::new(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]), &bytes[16..]))
     }
 }
 
@@ -370,45 +363,6 @@ impl PackedNode {
         }
     }
 
-    // TODO: ↓ convert into a block comment once rust bug #12834 gets fixed
-    /// Parse bytes into multiple `PackedNode`s.
-    ///
-    /// If provided bytes are smaller than [`PACKED_NODE_IPV4_SIZE`]
-    /// (./constant.PACKED_NODE_IPV4_SIZE.html) or can't be parsed, returns
-    /// `None`.
-    ///
-    /// Parses nodes until first error is encountered.
-    pub fn from_bytes_multiple(bytes: &[u8]) -> Option<Vec<PackedNode>> {
-        debug!(target: "PackedNode", "De-serializing multiple PackedNode.");
-        trace!(target: "PackedNode", "With bytes: {:?}", bytes);
-
-        if bytes.len() < PACKED_NODE_IPV4_SIZE {
-            debug!("There are less bytes than PACKED_NODE_IPV4_SIZE!");
-            return None
-        }
-
-        let mut cur_pos = 0;
-        let mut result = Vec::new();
-
-        // TODO: add `trace!()` logging?
-        while let Some(node) = PackedNode::from_bytes(&bytes[cur_pos..]) {
-            cur_pos += {
-                match node.ip_type {
-                    IpType::U4 | IpType::T4 => PACKED_NODE_IPV4_SIZE,
-                    IpType::U6 | IpType::T6 => PACKED_NODE_IPV6_SIZE,
-                }
-            };
-            result.push(node);
-        }
-
-        trace!("Result: {:?}", &result);
-        if result.is_empty() {
-            debug!("There is no successfully de-serialized PackedNodes!");
-            None
-        } else {
-            Some(result)
-        }
-    }
 }
 
 /** Serialize `PackedNode` into bytes.
@@ -453,11 +407,15 @@ impl ToBytes for PackedNode {
     address.
 */
 impl FromBytes<PackedNode> for PackedNode {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         // parse bytes as IPv4
-        fn as_ipv4(bytes: &[u8]) -> Option<(SocketAddr, PublicKey)> {
+        fn as_ipv4(iptype: IpType, bytes: &[u8]) -> ParseResult<PackedNode> {
             debug!("Parsing bytes as IPv4.");
             trace!("Bytes: {:?}", bytes);
+            if bytes.len() < PACKED_NODE_IPV4_SIZE {
+                return parse_error!("Less bytes than PACKED_NODE_IPV4_SIZE!")
+            }
+
             let addr = Ipv4Addr::new(bytes[1], bytes[2], bytes[3], bytes[4]);
             let port = u16::from_be(array_to_u16(&[bytes[5], bytes[6]]));
             let saddr = SocketAddrV4::new(addr, port);
@@ -465,71 +423,61 @@ impl FromBytes<PackedNode> for PackedNode {
             let pk = match PublicKey::from_slice(&bytes[7..PACKED_NODE_IPV4_SIZE]) {
                 Some(pk) => pk,
                 None => {
-                    trace!("Not enough bytes to parse as PK after IPv4.");
-                    return None
+                    return parse_error!("Not enough bytes to parse as PK after IPv4.")
                 },
             };
 
-            Some((SocketAddr::V4(saddr), pk))
+            let result = PackedNode {
+                ip_type: iptype,
+                saddr: SocketAddr::V4(saddr),
+                pk: pk
+            };
+
+            Ok(Parsed(result, &bytes[PACKED_NODE_IPV4_SIZE..]))
         }
 
-        // parse bytes as IPv4
-        fn as_ipv6(bytes: &[u8]) -> Option<(SocketAddr, PublicKey)> {
+        // parse bytes as IPv6
+        fn as_ipv6(iptype: IpType, bytes: &[u8]) -> ParseResult<PackedNode> {
             trace!("Parsing bytes as IPv6.");
             trace!("Bytes: {:?}", bytes);
             if bytes.len() < PACKED_NODE_IPV6_SIZE {
-                debug!("Less bytes than PACKED_NODE_IPV6_SIZE!");
-                return None
+                return parse_error!("Less bytes than PACKED_NODE_IPV6_SIZE!")
             }
 
-            let addr = match Ipv6Addr::from_bytes(&bytes[1..]) {
-                Some(a) => a,
-                None    => return None,
-            };
+            let Parsed(addr, _) = try!(Ipv6Addr::parse_bytes(&bytes[1..]));
             let port = u16::from_be(array_to_u16(&[bytes[17], bytes[18]]));
             let saddr = SocketAddrV6::new(addr, port, 0, 0);
 
             let pk = match PublicKey::from_slice(&bytes[19..PACKED_NODE_IPV6_SIZE]) {
                 Some(p) => p,
                 None    => {
-                    trace!("Not enough bytes to parse as PK after IPv6.");
-                    return None
+                    return parse_error!("Not enough bytes to parse as PK after IPv6.")
                 },
             };
 
-            Some((SocketAddr::V6(saddr), pk))
+            let result = PackedNode {
+                ip_type: iptype,
+                saddr: SocketAddr::V6(saddr),
+                pk: pk
+            };
+
+            Ok(Parsed(result, &bytes[PACKED_NODE_IPV6_SIZE..]))
         }
 
 
         debug!(target: "PackedNode", "De-serializing bytes into PackedNode.");
         trace!(target: "PackedNode", "With bytes: {:?}", bytes);
 
-        if bytes.len() >= PACKED_NODE_IPV4_SIZE {
-            let (iptype, saddr_and_pk) = match IpType::from_bytes(bytes) {
-                Some(IpType::U4) => (IpType::U4, as_ipv4(bytes)),
-                Some(IpType::T4) => (IpType::T4, as_ipv4(bytes)),
-                Some(IpType::U6) => (IpType::U6, as_ipv6(bytes)),
-                Some(IpType::T6) => (IpType::T6, as_ipv6(bytes)),
-                None => return None,
-            };
-
-            let (saddr, pk) = match saddr_and_pk {
-                Some(v) => v,
-                None => {
-                    debug!("Parsing failed, no saddr & PK.");
-                    return None
-                },
-            };
-
-            return Some(PackedNode {
-                ip_type: iptype,
-                saddr: saddr,
-                pk: pk,
-            });
+        if bytes.len() < PACKED_NODE_IPV4_SIZE {
+            return parse_error!("Not enough bytes; less than PACKED_NODE_IPV4_SIZE")
         }
-        // `if` not triggered
-        debug!("Not enough bytes; less than PACKED_NODE_IPV4_SIZE");
-        None
+
+        match try!(IpType::parse_bytes(bytes)) {
+            Parsed(IpType::U4, _) => as_ipv4(IpType::U4, bytes),
+            Parsed(IpType::T4, _) => as_ipv4(IpType::T4, bytes),
+            Parsed(IpType::U6, _) => as_ipv6(IpType::U6, bytes),
+            Parsed(IpType::T6, _) => as_ipv6(IpType::T6, bytes),
+        }
     }
 }
 
@@ -593,13 +541,12 @@ impl ToBytes for GetNodes {
     de-serialization will fail, returning `None`.
 */
 impl FromBytes<GetNodes> for GetNodes {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "GetNodes", "De-serializing bytes into GetNodes.");
         trace!(target: "GetNodes", "With bytes: {:?}", bytes);
 
         if bytes.len() < GET_NODES_SIZE {
-            debug!("Amount of bytes is less than GET_NODES_SIZE!");
-            return None
+            return parse_error!("Amount of bytes is less than GET_NODES_SIZE!")
         }
 
         if let Some(pk) = PublicKey::from_slice(&bytes[..PUBLICKEYBYTES]) {
@@ -607,10 +554,10 @@ impl FromBytes<GetNodes> for GetNodes {
             let b = &bytes[PUBLICKEYBYTES..GET_NODES_SIZE];
             let id = array_to_u64(&[b[0], b[1], b[2], b[3],
                                     b[4], b[5], b[6], b[7]]);
-            return Some(GetNodes { pk: pk, id: id })
+            Ok(Parsed(GetNodes { pk: pk, id: id }, &bytes[PUBLICKEYBYTES..]))
+        } else {
+            return parse_error!("Failed to de-serialize bytes into GetNodes!")
         }
-        debug!("Failed to de-serialize bytes into GetNodes!");
-        None  // de-serialization failed
     }
 }
 
@@ -693,41 +640,26 @@ impl ToBytes for SendNodes {
     Returns `None` if bytes can't be parsed into `SendNodes`.
 */
 impl FromBytes<SendNodes> for SendNodes {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "SendNodes", "De-serializing bytes into SendNodes.");
         trace!(target: "SendNodes", "With bytes: {:?}", bytes);
 
+        let nodes_number = bytes[0] as usize;
+
         // first byte should say how many `PackedNode`s `SendNodes` has.
         // There has to be at least 1 node, and no more than 4.
-        if bytes[0] < 1 || bytes[0] > 4 {
-            warn!(target: "SendNodes", "Wrong number of nodes: {}", bytes[0]);
-            return None
+        if nodes_number < 1 || nodes_number > 4 {
+            return parse_error!(target: "SendNodes", "Wrong number of nodes: {}", bytes[0])
         }
 
-        if let Some(nodes) = PackedNode::from_bytes_multiple(&bytes[1..]) {
-            if nodes.len() != bytes[0] as usize {
-                warn!(target: "SendNodes", "Wrong number of nodes; Expected:
-                      {}; Has: {}", bytes[0], nodes.len());
-                return None
-            }
-
-            // since 1st byte is a number of nodes
-            let mut nodes_bytes_len = 1;
-            // TODO: ↓ most likely can be done more efficiently
-            for node in &nodes {
-                nodes_bytes_len += node.to_bytes().len();
-            }
-
-            // need u64 from bytes
-            let mut ping_id: [u8; 8] = [0; 8];
-            for (pos, item) in ping_id.iter_mut().enumerate() {
-                *item = bytes[nodes_bytes_len + pos];
-            }
-
-            return Some(SendNodes { nodes: nodes, id: array_to_u64(&ping_id) })
+        let Parsed(nodes, rest) = try!(PackedNode::parse_bytes_multiple_n(nodes_number, &bytes[1..]));
+        // need u64 from bytes
+        let mut ping_id: [u8; 8] = [0; 8];
+        for (pos, item) in ping_id.iter_mut().enumerate() {
+            *item = rest[pos];
         }
-        debug!("De-serializing from bytes into SendNodes failed!");
-        None  // parsing failed
+
+        Ok(Parsed(SendNodes { nodes: nodes, id: array_to_u64(&ping_id) }, &rest[8..]))
     }
 }
 
@@ -945,59 +877,46 @@ impl ToBytes for DhtPacket {
 
 /// De-serialize bytes into `DhtPacket`.
 impl FromBytes<DhtPacket> for DhtPacket {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "DhtPacket", "De-serializing bytes into DhtPacket.");
         trace!(target: "DhtPacket", "With bytes: {:?}", bytes);
 
         if bytes.len() < DHT_PACKET_MIN_SIZE {
-            debug!("Failed; less bytes than DHT_PACKET_MIN_SIZE!");
-            return None
+            return parse_error!("Failed; less bytes than DHT_PACKET_MIN_SIZE!")
         }
 
-        let packet_type = match PacketKind::from_bytes(bytes) {
-            Some(b) => {
-                match b {
-                    PacketKind::PingReq | PacketKind::PingResp |
-                    PacketKind::GetN | PacketKind::SendN => b,
-                    p => {
-                        debug!("Failed: not a DHT packet!");
-                        trace!("Packet: {:?}", p);
-                        return None  // not a DHT packet
-                    },
-                }
-            },
-            None => {
-                debug!("Failed: not a recognisable PacketKind!");
-                return None
-            },
-        };
+        let Parsed(packet_type, bytes) = try!(PacketKind::parse_bytes(bytes));
 
-        const NONCE_POS: usize = 1 + PUBLICKEYBYTES;
-        let sender_pk = match PublicKey::from_slice(&bytes[1..NONCE_POS]) {
+        match packet_type {
+            PacketKind::PingReq | PacketKind::PingResp |
+            PacketKind::GetN | PacketKind::SendN => {},
+            p => {
+                return parse_error!("Failed: not a DHT packet! Packet: {:?}", p)
+            },
+        }
+
+        let sender_pk = match PublicKey::from_slice(&bytes[..PUBLICKEYBYTES]) {
             Some(pk) => pk,
             None => {
-                debug!("Failed; de-serializing sender's PK!");
-                trace!("With bytes for PK: {:?}", &bytes[1..NONCE_POS]);
-                return None
+                return parse_error!("Failed; de-serializing sender's PK! With bytes for PK: {:?}", &bytes[..PUBLICKEYBYTES])
             },
         };
+        let bytes = &bytes[PUBLICKEYBYTES..];
 
-        const PAYLOAD_POS: usize = NONCE_POS + NONCEBYTES;
-        let nonce = match Nonce::from_slice(&bytes[NONCE_POS..PAYLOAD_POS]) {
+        let nonce = match Nonce::from_slice(&bytes[..NONCEBYTES]) {
             Some(n) => n,
             None => {
-                debug!("Failed; de-serializing nonce!");
-                trace!("With bytes for nonce: {:?}", &bytes[NONCE_POS..PAYLOAD_POS]);
-                return None
+                return parse_error!("Failed; de-serializing nonce! With bytes for nonce: {:?}", &bytes[..NONCEBYTES])
             },
         };
+        let bytes = &bytes[NONCEBYTES..];
 
-        Some(DhtPacket {
+        Ok(Parsed(DhtPacket {
             packet_type: packet_type,
             sender_pk: sender_pk,
             nonce: nonce,
-            payload: bytes[PAYLOAD_POS..].to_vec(),
-        })
+            payload: bytes.to_vec(),
+        }, &bytes[..0]))
     }
 }
 
@@ -1407,17 +1326,17 @@ impl ToBytes for NatPing {
 }
 
 impl FromBytes<NatPing> for NatPing {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         if bytes.len() < NAT_PING_SIZE {
-            return None
+            return parse_error!("Not enough bytes for NatPing.")
         }
 
         if bytes[0] != NAT_PING_TYPE {
-            return None
+            return parse_error!("Not a NatPing.")
         }
 
-        Ping::from_bytes(&bytes[1..NAT_PING_SIZE])
-            .and_then(|p| Some(NatPing(p)))
+        let Parsed(p, rest) = try!(Ping::parse_bytes(&bytes[1..]));
+        Ok(Parsed(NatPing(p), rest))
     }
 }
 
@@ -1451,9 +1370,9 @@ impl ToBytes for DhtRequestT {
 }
 
 impl FromBytes<DhtRequestT> for DhtRequestT {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        NatPing::from_bytes(bytes)
-            .and_then(|p| Some(DhtRequestT::NatPing(p)))
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        let Parsed(p, rest) = try!(NatPing::parse_bytes(bytes));
+        Ok(Parsed(DhtRequestT::NatPing(p), rest))
     }
 }
 

--- a/src/toxcore/packet_kind.rs
+++ b/src/toxcore/packet_kind.rs
@@ -81,39 +81,39 @@ pub enum PacketKind {
     Returns `None` if no bytes provided, or first byte doesn't match.
 */
 impl FromBytes<PacketKind> for PacketKind {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
         debug!(target: "PacketKind", "Creating PacketKind from bytes.");
         trace!(target: "PacketKind", "Bytes: {:?}", bytes);
         if bytes.is_empty() {
-            debug!("There are 0 bytes!");
-            return None
+            return parse_error!("There are 0 bytes!")
         }
 
-        match bytes[0] {
-            0   => Some(PacketKind::PingReq),
-            1   => Some(PacketKind::PingResp),
-            2   => Some(PacketKind::GetN),
-            4   => Some(PacketKind::SendN),
-            24  => Some(PacketKind::CookieReq),
-            25  => Some(PacketKind::CookieResp),
-            26  => Some(PacketKind::CryptoHs),
-            27  => Some(PacketKind::CryptoData),
-            32  => Some(PacketKind::DhtReq),
-            33  => Some(PacketKind::LanDisc),
-            128 => Some(PacketKind::OnionReq0),
-            129 => Some(PacketKind::OnionReq1),
-            130 => Some(PacketKind::OnionReq2),
-            131 => Some(PacketKind::AnnReq),
-            132 => Some(PacketKind::AnnResp),
-            133 => Some(PacketKind::OnionDataReq),
-            134 => Some(PacketKind::OnionDataResp),
-            140 => Some(PacketKind::OnionResp3),
-            141 => Some(PacketKind::OnionResp2),
-            142 => Some(PacketKind::OnionResp1),
+        let result = match bytes[0] {
+            0   => PacketKind::PingReq,
+            1   => PacketKind::PingResp,
+            2   => PacketKind::GetN,
+            4   => PacketKind::SendN,
+            24  => PacketKind::CookieReq,
+            25  => PacketKind::CookieResp,
+            26  => PacketKind::CryptoHs,
+            27  => PacketKind::CryptoData,
+            32  => PacketKind::DhtReq,
+            33  => PacketKind::LanDisc,
+            128 => PacketKind::OnionReq0,
+            129 => PacketKind::OnionReq1,
+            130 => PacketKind::OnionReq2,
+            131 => PacketKind::AnnReq,
+            132 => PacketKind::AnnResp,
+            133 => PacketKind::OnionDataReq,
+            134 => PacketKind::OnionDataResp,
+            140 => PacketKind::OnionResp3,
+            141 => PacketKind::OnionResp2,
+            142 => PacketKind::OnionResp1,
             _   => {
-                debug!("Byte can't be parsed as PacketKind!");
-                None
+                return parse_error!("Byte can't be parsed as PacketKind!")
             },
-        }
+        };
+
+        Ok(Parsed(result, &bytes[1..]))
     }
 }

--- a/src/toxcore/state_format/old.rs
+++ b/src/toxcore/state_format/old.rs
@@ -115,19 +115,21 @@ assert_eq!(SectionKind::EOF,
 ```
 */
 impl FromBytes<SectionKind> for SectionKind {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        match bytes[0] {
-            0x01 => Some(SectionKind::NospamKeys),
-            0x02 => Some(SectionKind::DHT),
-            0x03 => Some(SectionKind::Friends),
-            0x04 => Some(SectionKind::Name),
-            0x05 => Some(SectionKind::StatusMsg),
-            0x06 => Some(SectionKind::Status),
-            0x0a => Some(SectionKind::TcpRelays),
-            0x0b => Some(SectionKind::PathNodes),
-            0xff => Some(SectionKind::EOF),
-            _ => None,
-        }
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        let result = match bytes[0] {
+            0x01 => SectionKind::NospamKeys,
+            0x02 => SectionKind::DHT,
+            0x03 => SectionKind::Friends,
+            0x04 => SectionKind::Name,
+            0x05 => SectionKind::StatusMsg,
+            0x06 => SectionKind::Status,
+            0x0a => SectionKind::TcpRelays,
+            0x0b => SectionKind::PathNodes,
+            0xff => SectionKind::EOF,
+            _ => return parse_error!("Incorrect SectionKind: {:x}.", bytes[0]),
+        };
+
+        Ok(Parsed(result, &bytes[1..]))
     }
 }
 
@@ -179,8 +181,10 @@ assert_eq!(result, NospamKeys::from_bytes(&bytes)
 ```
 */
 impl FromBytes<NospamKeys> for NospamKeys {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() < NOSPAMKEYSBYTES { return None }
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        if bytes.len() < NOSPAMKEYSBYTES {
+            return parse_error!("Not enough bytes for NospamKeys.")
+        }
 
         let nospam = NoSpam([bytes[0], bytes[1], bytes[2], bytes[3]]);
 
@@ -188,17 +192,17 @@ impl FromBytes<NospamKeys> for NospamKeys {
                     &bytes[NOSPAMBYTES..PUBLICKEYBYTES + NOSPAMBYTES]) {
 
             Some(pk) => pk,
-            None => return None,
+            None => return parse_error!("Can't parse PublicKey."),
         };
 
         let sk = match SecretKey::from_slice(
                     &bytes[NOSPAMBYTES + PUBLICKEYBYTES..NOSPAMKEYSBYTES]) {
 
             Some(sk) => sk,
-            None => return None,
+            None => return parse_error!("Can't parse SecretKey."),
         };
 
-        Some(NospamKeys { nospam: nospam, pk: pk, sk: sk })
+        Ok(Parsed(NospamKeys { nospam: nospam, pk: pk, sk: sk }, &bytes[NOSPAMKEYSBYTES..]))
     }
 }
 
@@ -328,16 +332,16 @@ assert_eq!(DhtState(vec![]), DhtState::from_bytes(&serialized).unwrap());
 ```
 */
 impl FromBytes<DhtState> for DhtState {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if
-            bytes.len() < DHT_STATE_MIN_SIZE ||
-            // check whether beginning of the section matches DHT magic bytes
-            &u32_to_array(DHT_MAGICAL.to_le()) != &bytes[..4] ||
-            // check DHT section type
-            &u16_to_array(DHT_SECTION_TYPE.to_le()) != &bytes[8..10] ||
-            // check whether yet another magic number matches ;f
-            &u16_to_array(DHT_2ND_MAGICAL.to_le()) != &bytes[10..12]
-        { return None } // can I haz yet another magical number?
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        if bytes.len() < DHT_STATE_MIN_SIZE ||
+           // check whether beginning of the section matches DHT magic bytes
+           &u32_to_array(DHT_MAGICAL.to_le()) != &bytes[..4] ||
+           // check DHT section type
+           &u16_to_array(DHT_SECTION_TYPE.to_le()) != &bytes[8..10] ||
+           // check whether yet another magic number matches ;f
+           &u16_to_array(DHT_2ND_MAGICAL.to_le()) != &bytes[10..12] {
+            return parse_error!("Incorect DhtState.")
+        } // can I haz yet another magical number?
 
         // length of the whole section
         let section_len = {
@@ -345,12 +349,15 @@ impl FromBytes<DhtState> for DhtState {
             let whole_len = u32::from_le(nodes) as usize + DHT_STATE_MIN_SIZE;
             // check if it's bigger, since that would be the only thing that
             // could cause panic
-            if whole_len > bytes.len() { return None }
+            if whole_len > bytes.len() {
+                return parse_error!("Not enough bytes for DhtState.")
+            }
             whole_len
         };
 
-        PackedNode::from_bytes_multiple(&bytes[DHT_STATE_MIN_SIZE..section_len])
-            .map_or(Some(DhtState(vec![])), |pns| Some(DhtState(pns)))
+        let nodes_bytes = &bytes[DHT_STATE_MIN_SIZE..section_len];
+        let Parsed(pns, _) = try!(PackedNode::parse_bytes_multiple(nodes_bytes));
+        Ok(Parsed(DhtState(pns), &bytes[section_len..]))
     }
 }
 
@@ -483,16 +490,21 @@ for i in 5..256 {
 ```
 */
 impl FromBytes<FriendStatus> for FriendStatus {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.is_empty() { return None }
-        match bytes[0] {
-            0 => Some(FriendStatus::NotFriend),
-            1 => Some(FriendStatus::Added),
-            2 => Some(FriendStatus::FrSent),
-            3 => Some(FriendStatus::Confirmed),
-            4 => Some(FriendStatus::Online),
-            _ => None,
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        if bytes.is_empty() {
+            return parse_error!("Not enough bytes for FriendStatus.")
         }
+
+        let result = match bytes[0] {
+            0 => FriendStatus::NotFriend,
+            1 => FriendStatus::Added,
+            2 => FriendStatus::FrSent,
+            3 => FriendStatus::Confirmed,
+            4 => FriendStatus::Online,
+            _ => return parse_error!("Unknown FriendStatus: {}.", bytes[0]),
+        };
+
+        Ok(Parsed(result, &bytes[1..]))
     }
 }
 
@@ -548,14 +560,19 @@ for i in 3..256 {
 ```
 */
 impl FromBytes<UserStatus> for UserStatus {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.is_empty() { return None }
-        match bytes[0] {
-            0 => Some(UserStatus::Online),
-            1 => Some(UserStatus::Away),
-            2 => Some(UserStatus::Busy),
-            _ => None,
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        if bytes.is_empty() {
+            return parse_error!("Not enough bytes for UserStatus.")
         }
+
+        let result = match bytes[0] {
+            0 => UserStatus::Online,
+            1 => UserStatus::Away,
+            2 => UserStatus::Busy,
+            _ => return parse_error!("Unknown UserStatus: {}.", bytes[0])
+        };
+
+        Ok(Parsed(result, &bytes[1..]))
     }
 }
 
@@ -597,68 +614,52 @@ pub const FRIENDSTATEBYTES: usize = 1      // "Status"
                                   + 8;     // last time seen
 
 impl FromBytes<FriendState> for FriendState {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() < FRIENDSTATEBYTES { return None }
+    fn parse_bytes(bytes: &[u8]) -> ParseResult<Self> {
+        if bytes.len() < FRIENDSTATEBYTES {
+            return parse_error!("Not enough bytes for FriendState.")
+        }
 
-        let status = match FriendStatus::from_bytes(&bytes) {
-            Some(s) => s,
-            None => return None,
-        };
+        let Parsed(status, bytes) = try!(FriendStatus::parse_bytes(bytes));
 
-        const PK_POS: usize = 1;
         let pk = match PublicKey::from_slice(
-                            &bytes[PK_POS..PUBLICKEYBYTES + PK_POS]) {
+                            &bytes[..PUBLICKEYBYTES]) {
             Some(pk) => pk,
-            None => return None,
+            None => return parse_error!("Can't parse PublicKey.")
         };
+        let bytes = &bytes[PUBLICKEYBYTES..];
 
-        // get string out of bytes in range (start, start+len]
-        // supply start position and *length*
-        let get_string = |start, len: usize| -> Option<String> {
+        // parse string out of bytes
+        // supply length
+        fn parse_string(bytes: &[u8], len: usize) -> ParseResult<String> {
             let str_len = u16::from_be(array_to_u16(
-                        &[bytes[start+len], bytes[start+len+1]])) as usize;
-            String::from_utf8(bytes[start..start+str_len].to_vec()).ok()
+                        &[bytes[len], bytes[len+1]])) as usize;
+            match String::from_utf8(bytes[..str_len].to_vec()).ok() {
+                Some(str) => Ok(Parsed(str, &bytes[len+2..])),
+                None => parse_error!("Can't parse string from bytes: '{:?}'.", &bytes[..len+2])
+            }
         };
 
-        const FR_MSG_POS: usize = PK_POS + PUBLICKEYBYTES;
         const FR_MSG_LEN: usize = 1024;
-        let fr_msg = match get_string(FR_MSG_POS, FR_MSG_LEN) {
-            Some(m) => m,
-            None => return None,
-        };
+        let Parsed(fr_msg, bytes) = try!(parse_string(bytes, FR_MSG_LEN));
 
-        const NAME_POS: usize = FR_MSG_POS + FR_MSG_LEN + 2;
         const NAME_LEN: usize = 128;
-        let name = match get_string(NAME_POS, NAME_LEN) {
-            Some(n) => n,
-            None => return None,
-        };
+        let Parsed(name, bytes) = try!(parse_string(bytes, NAME_LEN));
 
-        const STATUS_MSG_POS: usize = NAME_POS + NAME_LEN + 2;
         const STATUS_MSG_LEN: usize = 1007;
-        let status_msg = match get_string(STATUS_MSG_POS, STATUS_MSG_LEN) {
-            Some(m) => m,
-            None => return None,
-        };
+        let Parsed(status_msg, bytes) = try!(parse_string(bytes, STATUS_MSG_LEN));
 
-        const USER_STATUS_POS: usize = STATUS_MSG_POS + STATUS_MSG_LEN + 2;
-        let user_status = match UserStatus::from_bytes(&bytes[USER_STATUS_POS..]) {
-            Some(s) => s,
-            None => return None,
-        };
+        let Parsed(user_status, bytes) = try!(UserStatus::parse_bytes(bytes));
 
-        const NOSPAM_POS: usize = USER_STATUS_POS + 4; // 1 byte status + padding
-        let nospam = match NoSpam::from_bytes(&bytes[NOSPAM_POS..]) {
-            Some(n) => n,
-            None => return None,
-        };
+        let bytes = &bytes[3..]; // padding
+        let Parsed(nospam, bytes) = try!(NoSpam::parse_bytes(&bytes));
 
-        const SPOS: usize = NOSPAM_POS + NOSPAMBYTES;
         let seen = u64::from_le(array_to_u64(&[
-            bytes[SPOS], bytes[SPOS+1], bytes[SPOS+2], bytes[SPOS+3],
-            bytes[SPOS+4], bytes[SPOS+5], bytes[SPOS+6], bytes[SPOS+7]]));
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7]]));
 
-        Some(FriendState {
+        let bytes = &bytes[8..];
+
+        Ok(Parsed(FriendState {
             status: status,
             pk: pk,
             fr_msg: fr_msg,
@@ -667,7 +668,7 @@ impl FromBytes<FriendState> for FriendState {
             user_status: user_status,
             nospam: nospam,
             last_seen: seen,
-        })
+        }, bytes))
     }
 }
 // TODO: write tests ↑

--- a/src/toxcore_tests/dht_tests.rs
+++ b/src/toxcore_tests/dht_tests.rs
@@ -341,26 +341,55 @@ fn packed_node_ip_test() {
 }
 
 
-// PackedNode::from_bytes_multiple()
+// PackedNode::parse_bytes_multiple()
 
 #[test]
 fn packed_node_from_bytes_multiple_test() {
     fn with_nodes(nodes: Vec<PackedNode>) {
         if nodes.is_empty() {
-            assert_eq!(None, PackedNode::from_bytes_multiple(&[]));
+            let nodes1 =
+                PackedNode::parse_bytes_multiple(&[])
+                    .ok()
+                    .map(|Parsed(v, _)| v);
+            assert_eq!(Some(vec![]), nodes1);
             return
         }
         let mut bytes = vec![];
         for n in nodes.clone() {
             bytes.extend_from_slice(&n.to_bytes());
         }
-        let nodes2 = PackedNode::from_bytes_multiple(&bytes).unwrap();
+        let Parsed(nodes2, _) = PackedNode::parse_bytes_multiple(&bytes).unwrap();
 
         assert_eq!(nodes.len(), nodes2.len());
         assert_eq!(nodes, nodes2);
     }
     quickcheck(with_nodes as fn(Vec<PackedNode>));
 }
+
+// PackedNode::parse_bytes_multiple_n()
+
+#[test]
+fn packed_node_from_bytes_multiple_n_test() {
+    fn with_nodes(nodes: Vec<PackedNode>) {
+        let mut bytes = vec![];
+        for n in nodes.clone() {
+            bytes.extend_from_slice(&n.to_bytes());
+        }
+        let Parsed(nodes2, _) = PackedNode::parse_bytes_multiple_n(nodes.len(), &bytes).unwrap();
+
+        assert_eq!(nodes.len(), nodes2.len());
+        assert_eq!(nodes, nodes2);
+
+        let nodes_err =
+            PackedNode::parse_bytes_multiple_n(nodes.len() + 1, &bytes)
+                .ok()
+                .map(|Parsed(v, _)| v);
+
+        assert_eq!(None, nodes_err);
+    }
+    quickcheck(with_nodes as fn(Vec<PackedNode>));
+}
+
 
 
 // PackedNode::to_bytes()

--- a/src/toxcore_tests/packet_kind_tests.rs
+++ b/src/toxcore_tests/packet_kind_tests.rs
@@ -23,6 +23,8 @@ use toxcore::packet_kind::PacketKind;
 
 use super::quickcheck::quickcheck;
 
+// PacketKind::from_bytes
+
 #[test]
 fn packet_kind_from_bytes_test() {
     fn with_bytes(bytes: Vec<u8>) {
@@ -63,4 +65,16 @@ fn packet_kind_from_bytes_test() {
     with_bytes(vec![2]);
     with_bytes(vec![3]);  // incorrect
     with_bytes(vec![4]);
+}
+
+// PacketKind::parse_bytes
+
+#[test]
+fn packet_kind_parse_bytes_rest_test() {
+    fn with_bytes(bytes: Vec<u8>) {
+        if let Ok(Parsed(_, rest)) = PacketKind::parse_bytes(&bytes) {
+            assert_eq!(&bytes[1..], rest);
+        }
+    }
+    quickcheck(with_bytes as fn(Vec<u8>));
 }

--- a/src/toxcore_tests/toxid_tests.rs
+++ b/src/toxcore_tests/toxid_tests.rs
@@ -82,6 +82,20 @@ fn no_spam_from_bytes_test() {
     quickcheck(with_bytes as fn(Vec<u8>));
 }
 
+// NoSpam::parse_bytes()
+
+#[test]
+fn no_spam_parse_bytes_rest_test() {
+    fn with_bytes(bytes: Vec<u8>) {
+        if bytes.len() >= NOSPAMBYTES {
+            let Parsed(_, rest) = NoSpam::parse_bytes(&bytes)
+                            .expect("Failed to get NoSpam!");
+            assert_eq!(&bytes[NOSPAMBYTES..], rest);
+        }
+    }
+    quickcheck(with_bytes as fn(Vec<u8>));
+}
+
 
 // ToxId::from_bytes()
 
@@ -95,6 +109,20 @@ fn tox_id_from_bytes_test() {
                             .expect("Failed to get ToxId!");
             let PublicKey(ref pk) = toxid.pk;
             assert_eq!(pk, &bytes[..PUBLICKEYBYTES]);
+        }
+    }
+    quickcheck(with_bytes as fn(Vec<u8>));
+}
+
+// ToxId::parse_bytes()
+
+#[test]
+fn tox_id_parse_bytes_rest_test() {
+    fn with_bytes(bytes: Vec<u8>) {
+        if bytes.len() >= TOXIDBYTES {
+            let Parsed(_, rest) = ToxId::parse_bytes(&bytes)
+                            .expect("Failed to get ToxId!");
+            assert_eq!(&bytes[TOXIDBYTES..], rest);
         }
     }
     quickcheck(with_bytes as fn(Vec<u8>));


### PR DESCRIPTION
new method parse_bytes in FromBytes trait
parse_bytes returns result with remaining input
