### PR TITLE
fix: reduce code in `unsafe` block

### DIFF
--- a/src/toxcore/crypto_core.rs
+++ b/src/toxcore/crypto_core.rs
@@ -55,10 +55,11 @@ pub fn crypto_init() -> bool {
     // NOTE: `init()` could be run more than once, but not in parallel, and
     //       `CRYPTO_INIT` *can't* be modified while it may be read by
     //       something else.
-    unsafe {
-        CRYPTO_INIT_ONCE.call_once(|| CRYPTO_INIT = ::sodiumoxide::init());
-        CRYPTO_INIT
-    }
+    CRYPTO_INIT_ONCE.call_once(|| {
+        let initialized = ::sodiumoxide::init();
+        unsafe { CRYPTO_INIT = initialized; }
+    });
+    unsafe { CRYPTO_INIT }
 }
 
 


### PR DESCRIPTION
Don't place code in `unsafe` block that can compile without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/53)
<!-- Reviewable:end -->
