### PR TITLE
feat: add method to `DhtNode` for sending `SendNode`s

### DIFF
--- a/src/toxcore/network.rs
+++ b/src/toxcore/network.rs
@@ -208,7 +208,9 @@ pub fn bind_udp(ip: IpAddr, port_range: Range<u16>, handle: &Handle)
     None  // loop ended without "early" return – failed to bind
 }
 
-/// Correct Port Range.
+/** Port Range, default is
+[`PORT_MIN`](./constant.PORT_MIN.html)..[`PORT_MAX`](./constant.PORT_MAX.html).
+*/
 #[derive(Clone, Debug, PartialEq)]
 pub struct PortRange<N>(pub Range<N>);
 

--- a/src/toxcore_tests/dht_tests.rs
+++ b/src/toxcore_tests/dht_tests.rs
@@ -1399,7 +1399,7 @@ fn kbucket_new_test() {
     fn with_pk(a: u64, b: u64, c: u64, d: u64, buckets: u8) {
         let pk = nums_to_pk(a, b, c, d);
         let kbucket = Kbucket::new(buckets, &pk);
-        assert_eq!(buckets, kbucket.k);
+        assert_eq!(buckets, kbucket.n);
         assert_eq!(pk, kbucket.pk);
     }
     quickcheck(with_pk as fn(u64, u64, u64, u64, u8));
@@ -1409,9 +1409,9 @@ fn kbucket_new_test() {
 
 #[test]
 fn kbucket_try_add_test() {
-    fn with_pns(pns: Vec<PackedNode>, k: u8, p1: u64, p2: u64, p3: u64, p4: u64) {
+    fn with_pns(pns: Vec<PackedNode>, n: u8, p1: u64, p2: u64, p3: u64, p4: u64) {
         let pk = nums_to_pk(p1, p2, p3, p4);
-        let mut kbucket = Kbucket::new(k, &pk);
+        let mut kbucket = Kbucket::new(n, &pk);
         for node in pns {
             // result may vary, so discard it
             // TODO: can be done better?


### PR DESCRIPTION
Also changed letter in Kbucket struct/methods to be consistent with what
it signifies in the spec. Previously `k` was used, which in the spec
represents number of nodes stored in a single Bucket, and was changed to
`n` which in the spec represents number of `Bucket`s in a Kbucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/54)
<!-- Reviewable:end -->
