### PR TITLE
Hide fields of PackedNode

### DIFF
--- a/src/toxcore/dht.rs
+++ b/src/toxcore/dht.rs
@@ -305,11 +305,11 @@ solely on the UDP.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct PackedNode {
     /// IP type, includes also info about protocol used.
-    pub ip_type: IpType,
+    ip_type: IpType,
     /// Socket addr of node.
-    pub saddr: SocketAddr,
+    saddr: SocketAddr,
     /// Public Key of the node.
-    pub pk: PublicKey,
+    pk: PublicKey,
 }
 
 /// Size in bytes of serialized [`PackedNode`](./struct.PackedNode.html) with
@@ -350,6 +350,13 @@ impl PackedNode {
         }
     }
 
+    /// Get an IP type from the `PackedNode`.
+    pub fn ip_type(&self) -> IpType {
+        trace!(target: "PackedNode", "Getting IP type from PackedNode.");
+        trace!("With address: {:?}", self);
+        self.ip_type
+    }
+
     /// Get an IP address from the `PackedNode`.
     pub fn ip(&self) -> IpAddr {
         trace!(target: "PackedNode", "Getting IP address from PackedNode.");
@@ -358,6 +365,20 @@ impl PackedNode {
             SocketAddr::V4(addr) => IpAddr::V4(*addr.ip()),
             SocketAddr::V6(addr) => IpAddr::V6(*addr.ip()),
         }
+    }
+
+    /// Get a Socket address from the `PackedNode`.
+    pub fn socket_addr(&self) -> SocketAddr {
+        trace!(target: "PackedNode", "Getting Socket address from PackedNode.");
+        trace!("With address: {:?}", self);
+        self.saddr
+    }
+
+    /// Get an IP address from the `PackedNode`.
+    pub fn pk(&self) -> &PublicKey {
+        trace!(target: "PackedNode", "Getting PK from PackedNode.");
+        trace!("With address: {:?}", self);
+        &self.pk
     }
 
 }

--- a/src/toxcore/dht_node.rs
+++ b/src/toxcore/dht_node.rs
@@ -95,14 +95,14 @@ impl DhtNode {
     {
         // request for nodes that are close to our own DHT PK
         let getn_req = &GetNodes::new(&self.dht_public_key);
-        let shared_secret = &encrypt_precompute(&peer.pk, &self.dht_secret_key);
+        let shared_secret = &encrypt_precompute(peer.pk(), &self.dht_secret_key);
         let nonce = &gen_nonce();
         let dht_packet = DhtPacket::new(shared_secret,
                                         &self.dht_public_key,
                                         nonce,
                                         getn_req).to_bytes();
 
-        let future_send = socket.send_dgram(dht_packet, peer.saddr);
+        let future_send = socket.send_dgram(dht_packet, peer.socket_addr());
         let (udpsocket, _) = self.reactor.as_mut().run(future_send)?;
         Ok(udpsocket)
     }
@@ -116,7 +116,7 @@ impl DhtNode {
                       peer: &PackedNode,
                       request: &GetNodes) -> io::Result<UdpSocket>
     {
-        let close_nodes = self.kbucket.get_closest(&peer.pk);
+        let close_nodes = self.kbucket.get_closest(peer.pk());
         if close_nodes.is_empty() {
             return Err(io::Error::new(ErrorKind::Other, "no nodes in kbucket"))
         }
@@ -129,14 +129,14 @@ impl DhtNode {
                         "failed to create SendNodes response")),
         };
 
-        let shared_secret = &encrypt_precompute(&peer.pk, &self.dht_secret_key);
+        let shared_secret = &encrypt_precompute(peer.pk(), &self.dht_secret_key);
         let nonce = &gen_nonce();
         let dht_packet = DhtPacket::new(shared_secret,
                                         &self.dht_public_key,
                                         nonce,
                                         &to_send).to_bytes();
 
-        let future_send = socket.send_dgram(dht_packet, peer.saddr);
+        let future_send = socket.send_dgram(dht_packet, peer.socket_addr());
         let (udpsocket, _) = self.reactor.as_mut().run(future_send)?;
         Ok(udpsocket)
     }

--- a/src/toxcore_tests/dht_tests.rs
+++ b/src/toxcore_tests/dht_tests.rs
@@ -403,11 +403,44 @@ impl Arbitrary for PackedNode {
 #[allow(non_snake_case)]
 fn packed_node_new_test_ip_type_UDP_IPv4() {
     let pk = PublicKey([0; PUBLICKEYBYTES]);
-    let info = PackedNode::new(true,
-                               SocketAddr::V4("0.0.0.0:0".parse().unwrap()),
-                               &pk);
-    assert_eq!(IpType::U4, info.ip_type);
-    assert_eq!(pk, info.pk);
+    let addr = SocketAddr::V4("0.0.0.0:1".parse().unwrap());
+    let info = PackedNode::new(true, addr, &pk);
+    assert_eq!(IpType::U4, info.ip_type());
+    assert_eq!(&pk, info.pk());
+    assert_eq!(addr, info.socket_addr());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn packed_node_new_test_ip_type_TCP_IPv4() {
+    let pk = PublicKey([0; PUBLICKEYBYTES]);
+    let addr = SocketAddr::V4("0.0.0.0:2".parse().unwrap());
+    let info = PackedNode::new(false, addr, &pk);
+    assert_eq!(IpType::T4, info.ip_type());
+    assert_eq!(&pk, info.pk());
+    assert_eq!(addr, info.socket_addr());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn packed_node_new_test_ip_type_UDP_IPv6() {
+    let pk = PublicKey([0; PUBLICKEYBYTES]);
+    let addr = SocketAddr::V6("[::]:3".parse().unwrap());
+    let info = PackedNode::new(true, addr, &pk);
+    assert_eq!(IpType::U6, info.ip_type());
+    assert_eq!(&pk, info.pk());
+    assert_eq!(addr, info.socket_addr());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn packed_node_new_test_ip_type_TCP_IPv6() {
+    let pk = PublicKey([0; PUBLICKEYBYTES]);
+    let addr = SocketAddr::V6("[::]:4".parse().unwrap());
+    let info = PackedNode::new(false, addr, &pk);
+    assert_eq!(IpType::T6, info.ip_type());
+    assert_eq!(&pk, info.pk());
+    assert_eq!(addr, info.socket_addr());
 }
 
 
@@ -720,7 +753,7 @@ fn packed_nodes_from_bytes_test_no_iptype() {
 fn packed_nodes_from_bytes_test_wrong_iptype() {
     fn fully_random(pn: PackedNode) {
         let mut vec = Vec::with_capacity(PACKED_NODE_IPV6_SIZE);
-        match pn.ip_type {
+        match pn.ip_type() {
             IpType::U4 => vec.push(IpType::U6 as u8),
             IpType::T4 => vec.push(IpType::T6 as u8),
             _ => return,
@@ -1175,7 +1208,7 @@ fn node_id_test() {
 fn node_pk_test() {
     fn with_pn(pn: PackedNode, timeout: u64) {
         let node = Node::new(&pn, timeout);
-        assert_eq!(pn.pk, *node.pk());
+        assert_eq!(pn.pk(), node.pk());
     }
     quickcheck(with_pn as fn(PackedNode, u64));
 }
@@ -1264,7 +1297,7 @@ fn bucket_remove_test() {
         let mut rng = StdGen::new(ChaChaRng::new_unseeded(), rng_num);
         for _ in 0..num {
             let node: PackedNode = Arbitrary::arbitrary(&mut rng);
-            rm_pubkeys.push(node.pk);
+            rm_pubkeys.push(*node.pk());
             drop(bucket.try_add(&pk, &node));
         }
 


### PR DESCRIPTION
This prohibits user from creating `PackedNode` with wrong fields, e.g.:

```
PackedNode {
    ip_type: IpType::U4,
    saddr: SocketAddr::V6("[::]:0".parse().unwrap()),
    pk: PublicKey([0; PUBLICKEYBYTES]),
};
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/56)
<!-- Reviewable:end -->
