### PR TITLE
feat(dht): split `Ping` into `PingReq` and `PingResp`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ fn main() {
     let nonce = gen_nonce();
 
     // now create Ping request
-    let ping = &Ping::new();
+    let ping = &PingReq::new();
 
     // with Ping packet create DhtPacket, and serialize it to bytes
     let dhtpacket = DhtPacket::new(&precomp, &pk, &nonce, ping).to_bytes();
@@ -101,7 +101,7 @@ fn main() {
     };
 
     // decrypt payload of the received packet
-    let payload: Ping = recv_packet.get_packet(&sk)
+    let payload: PingResp = recv_packet.get_packet(&sk)
         .expect("Failed to decrypt payload!");
 
     assert_eq!(PacketKind::PingResp, payload.kind());


### PR DESCRIPTION
Following, also `NatPing` was split in the same manner.

Also changed `DhtRequestT` from an enum to trait to ease usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/58)
<!-- Reviewable:end -->
