### PR TITLE
Speedup tests

### DIFF
--- a/src/toxcore/state_format/old.rs
+++ b/src/toxcore/state_format/old.rs
@@ -30,7 +30,7 @@ use toxcore::toxid::{NoSpam, NOSPAMBYTES};
 
 
 #[cfg(test)]
-use ::toxcore_tests::quickcheck::{Arbitrary, Gen, quickcheck, TestResult};
+use ::toxcore_tests::quickcheck::*;
 
 
 // TODO: add logging where it's missing
@@ -1722,7 +1722,7 @@ macro_rules! section_data_into_sect_mult_into {
                     }));
                 }
             }
-            quickcheck(with_sects as fn(Vec<$sect>));
+            QuickCheck::new().max_tests(20).quickcheck(with_sects as fn(Vec<$sect>));
         }
     )+)
 }

--- a/src/toxencryptsave/mod.rs
+++ b/src/toxencryptsave/mod.rs
@@ -66,7 +66,7 @@ pub use sodiumoxide::crypto::box_::PRECOMPUTEDKEYBYTES as KEY_LENGTH;
 use ::toxcore::crypto_core;
 
 #[cfg(test)]
-use ::toxcore_tests::quickcheck::{quickcheck, TestResult};
+use ::toxcore_tests::quickcheck::{QuickCheck, TestResult};
 
 
 /// Length (in bytes) of [`MAGIC_NUMBER`](./constant.MAGIC_NUMBER.html).
@@ -458,7 +458,7 @@ fn pass_key_new_test() {
         assert!(pk.key.0 != [0; KEY_LENGTH]);
         TestResult::passed()
     }
-    quickcheck(with_pw as fn(Vec<u8>) -> TestResult);
+    QuickCheck::new().max_tests(20).quickcheck(with_pw as fn(Vec<u8>) -> TestResult);
 }
 
 // PassKey::with_salt()
@@ -478,5 +478,5 @@ fn pass_key_with_salt_test() {
         assert!(pk.key.0 != [0; KEY_LENGTH]);
         TestResult::passed()
     }
-    quickcheck(with_pw as fn(Vec<u8>) -> TestResult);
+    QuickCheck::new().max_tests(20).quickcheck(with_pw as fn(Vec<u8>) -> TestResult);
 }

--- a/src/toxencryptsave_tests/encryptsave_tests.rs
+++ b/src/toxencryptsave_tests/encryptsave_tests.rs
@@ -19,12 +19,7 @@
 */
 
 
-use super::quickcheck::{
-    Arbitrary,
-    Gen,
-    quickcheck,
-    TestResult,
-};
+use super::quickcheck::*;
 
 use toxencryptsave::*;
 
@@ -61,7 +56,7 @@ fn pass_key_encrypt_test() {
         assert_eq!(plain, passk.decrypt(&encrypted).expect("Decrypting failed"));
         TestResult::passed()
     }
-    quickcheck(with_data as fn(Vec<u8>, PassKey) -> TestResult);
+    QuickCheck::new().max_tests(20).quickcheck(with_data as fn(Vec<u8>, PassKey) -> TestResult);
 }
 
 // PassKey::decrypt()
@@ -100,7 +95,7 @@ fn pass_key_decrypt_test() {
 
         TestResult::passed()
     }
-    quickcheck(with_data as fn(Vec<u8>, PassKey) -> TestResult);
+    QuickCheck::new().max_tests(20).quickcheck(with_data as fn(Vec<u8>, PassKey) -> TestResult);
 }
 
 
@@ -143,7 +138,8 @@ fn pass_encrypt_test() {
 
         TestResult::passed()
     }
-    quickcheck(with_data_pass as fn(Vec<u8>, Vec<u8>) -> TestResult);
+    QuickCheck::new().max_tests(20).quickcheck(with_data_pass as
+        fn(Vec<u8>, Vec<u8>) -> TestResult);
 
     {
         use sodiumoxide::randombytes::randombytes;
@@ -192,7 +188,7 @@ fn get_salt_test() {
             assert_eq!(None, get_salt(&v));
         }
     }
-    quickcheck(with_bytes as fn(Vec<u8>));
+    QuickCheck::new().max_tests(20).quickcheck(with_bytes as fn(Vec<u8>));
 
     assert_eq!(
         get_salt(include_bytes!("ciphertext")).unwrap().0,


### PR DESCRIPTION
List of tests to optimize:

- [x] encryptsave
- [x] toxcore::state_format

## BEFORE

```
# tests were precompiled
$ time cargo test
real	1m57.862s
user	7m53.836s
sys	0m9.240s
```

## AFTER

```
# tests were precompiled
$ time cargo test
real	0m25.781s
user	2m33.120s
sys	0m5.420s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/64)
<!-- Reviewable:end -->
