### PR TITLE
fix(tests): move `quickcheck` out of `toxcore_tests`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,15 +127,18 @@ extern crate log;
 // for Zero trait
 extern crate num_traits;
 extern crate sodiumoxide;
+
+#[cfg(test)]
+extern crate quickcheck;
+
 extern crate tokio_core;
 extern crate tokio_proto;
 
 
 // TODO: refactor macros
-#[macro_use]
 #[cfg(test)]
+#[macro_use]
 pub mod toxcore_tests {
-    pub extern crate quickcheck;
     extern crate rand;
     extern crate rustc_serialize;
     extern crate regex;
@@ -182,7 +185,6 @@ pub mod toxencryptsave;
 
 #[cfg(test)]
 mod toxencryptsave_tests {
-    extern crate quickcheck;
     extern crate rand;
 
     mod encryptsave_tests;

--- a/src/toxcore/dht_node.rs
+++ b/src/toxcore/dht_node.rs
@@ -211,7 +211,7 @@ mod test {
     use toxcore::dht_node::ToxCodec;
     use toxcore::packet_kind::PacketKind;
 
-    use toxcore_tests::quickcheck::{quickcheck, TestResult};
+    use quickcheck::{quickcheck, TestResult};
 
     /// Bind to this IpAddr.
     // NOTE: apparently using `0.0.0.0`/`::` is not allowed on CIs like

--- a/src/toxcore/state_format/old.rs
+++ b/src/toxcore/state_format/old.rs
@@ -30,8 +30,7 @@ use toxcore::toxid::{NoSpam, NOSPAMBYTES};
 
 
 #[cfg(test)]
-use ::toxcore_tests::quickcheck::*;
-
+use quickcheck::*;
 
 // TODO: add logging where it's missing
 

--- a/src/toxcore_tests/binary_io_tests.rs
+++ b/src/toxcore_tests/binary_io_tests.rs
@@ -20,7 +20,7 @@
 //! Tests for `binary_io` module.
 
 use num_traits::identities::Zero;
-use super::quickcheck::{quickcheck, TestResult};
+use quickcheck::{quickcheck, TestResult};
 
 use toxcore::binary_io::*;
 

--- a/src/toxcore_tests/crypto_core_tests.rs
+++ b/src/toxcore_tests/crypto_core_tests.rs
@@ -27,7 +27,7 @@ use std::thread;
 use toxcore::crypto_core::*;
 use toxcore::binary_io::*;
 
-use super::quickcheck::quickcheck;
+use quickcheck::quickcheck;
 
 
 // crypto_init()

--- a/src/toxcore_tests/dht_tests.rs
+++ b/src/toxcore_tests/dht_tests.rs
@@ -37,7 +37,7 @@ use std::net::{
 use std::str::FromStr;
 use byteorder::{ByteOrder, BigEndian, LittleEndian, NativeEndian, WriteBytesExt};
 
-use super::quickcheck::{Arbitrary, Gen, quickcheck, StdGen, TestResult};
+use quickcheck::{Arbitrary, Gen, quickcheck, StdGen, TestResult};
 use super::rand::chacha::ChaChaRng;
 
 

--- a/src/toxcore_tests/packet_kind_tests.rs
+++ b/src/toxcore_tests/packet_kind_tests.rs
@@ -21,7 +21,7 @@
 use toxcore::binary_io::*;
 use toxcore::packet_kind::PacketKind;
 
-use super::quickcheck::{Arbitrary, Gen, quickcheck};
+use quickcheck::{Arbitrary, Gen, quickcheck};
 
 // PacketKind::
 

--- a/src/toxcore_tests/state_format_old_tests.rs
+++ b/src/toxcore_tests/state_format_old_tests.rs
@@ -21,7 +21,7 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 
-use super::quickcheck::{Arbitrary, Gen, TestResult, quickcheck};
+use quickcheck::{Arbitrary, Gen, TestResult, quickcheck};
 
 use toxcore::binary_io::*;
 use toxcore::dht::*;

--- a/src/toxcore_tests/test_macros.rs
+++ b/src/toxcore_tests/test_macros.rs
@@ -39,7 +39,7 @@ E.g.
 
 ```
 #[cfg(test)]
-use ::toxcore_tests::quickcheck::Arbitrary;
+use ::quickcheck::Arbitrary;
 
 struct Name(Vec<u8>);
 
@@ -67,7 +67,7 @@ macro_rules! impl_arb_for_bytes {
 E.g.
 
 ```
-use ::toxcore_tests::quickcheck::Arbitrary;
+use ::quickcheck::Arbitrary;
 use ::toxcore::dht::*;
 
 struct Nodes(Vec<PackedNode>);

--- a/src/toxcore_tests/toxid_tests.rs
+++ b/src/toxcore_tests/toxid_tests.rs
@@ -19,7 +19,7 @@
 
 //! Tests for `toxid` module.
 
-use super::quickcheck::quickcheck;
+use quickcheck::quickcheck;
 use super::regex::Regex;
 
 use toxcore::binary_io::*;

--- a/src/toxencryptsave/mod.rs
+++ b/src/toxencryptsave/mod.rs
@@ -66,7 +66,7 @@ pub use sodiumoxide::crypto::box_::PRECOMPUTEDKEYBYTES as KEY_LENGTH;
 use ::toxcore::crypto_core;
 
 #[cfg(test)]
-use ::toxcore_tests::quickcheck::{QuickCheck, TestResult};
+use quickcheck::{QuickCheck, TestResult};
 
 
 /// Length (in bytes) of [`MAGIC_NUMBER`](./constant.MAGIC_NUMBER.html).

--- a/src/toxencryptsave_tests/encryptsave_tests.rs
+++ b/src/toxencryptsave_tests/encryptsave_tests.rs
@@ -19,7 +19,7 @@
 */
 
 
-use super::quickcheck::*;
+use quickcheck::*;
 
 use toxencryptsave::*;
 


### PR DESCRIPTION
Closes #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/69)
<!-- Reviewable:end -->
