### PR TITLE
Improve tcp relay examples

### DIFF
--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -21,29 +21,39 @@
 
 extern crate tox;
 extern crate futures;
-extern crate bytes;
-extern crate nom;
 extern crate tokio_core;
 extern crate tokio_io;
 
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+extern crate rustc_serialize;
+use rustc_serialize::hex::FromHex;
+
 use tox::toxcore::crypto_core::*;
-use tox::toxcore::tcp::*;
+use tox::toxcore::tcp::packet::*;
+use tox::toxcore::tcp::make_client_handshake;
 use tox::toxcore::tcp::codec;
 
-use futures::{Stream, Future};
+use futures::prelude::*;
+use futures::future;
+use futures::sync::mpsc;
 
-use tokio_io::*;
-use tokio_core::reactor::Core;
+use tokio_io::{AsyncRead, IoFuture};
+use tokio_core::reactor::{Core, Handle};
 use tokio_core::net::TcpStream;
 
-fn main() {
-    // Server constant PK for examples/tests
+use std::{thread, time};
+use std::io::{Error, ErrorKind};
+
+// Notice that create_client create a future of client processing.
+//  The future will live untill all copies of tx is dropped or there is a IO error
+//  Since we pass a copy of tx as arg (to send PongResponses), the client will live untill IO error
+//  Comment out pong responser and client will be destroyed when there will be no messages to send
+fn create_client(rx: mpsc::Receiver<Packet>, tx: mpsc::Sender<Packet>, handle: &Handle) -> IoFuture<()> {
     // Use `gen_keypair` to generate random keys
-    let server_pk = PublicKey([177, 185, 54, 250, 10, 168, 174,
-                            148, 0, 93, 99, 13, 131, 131, 239,
-                            193, 129, 141, 80, 158, 50, 133, 100,
-                            182, 179, 183, 234, 116, 142, 102, 53, 38]);
-    // Some constant keypair for client
+    // Client constant keypair for examples/tests
     let client_pk = PublicKey([252, 72, 40, 127, 213, 13, 0, 95,
                               13, 230, 176, 49, 69, 252, 220, 132,
                               48, 73, 227, 58, 218, 154, 215, 245,
@@ -53,20 +63,165 @@ fn main() {
                               46, 163, 145, 242, 139, 125, 159,
                               137, 174, 14, 225, 7, 138, 120, 185, 153]);
 
-    let addr = "0.0.0.0:12345".parse().unwrap();
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
+    let (addr, server_pk) = match 1 {
+        1 => {
+            // local tcp relay server from example
+            let addr = "0.0.0.0:12345".parse().unwrap();
+            // Server constant PK for examples/tests
+            let server_pk = PublicKey([177, 185, 54, 250, 10, 168, 174,
+                                    148, 0, 93, 99, 13, 131, 131, 239,
+                                    193, 129, 141, 80, 158, 50, 133, 100,
+                                    182, 179, 183, 234, 116, 142, 102, 53, 38]);
+            (addr, server_pk)
+        },
+        2 => {
+            // remote tcp relay server
+            let server_pk_bytes = FromHex::from_hex("461FA3776EF0FA655F1A05477DF1B3B614F7D6B124F7DB1DD4FE3C08B03B640F").unwrap();
+            let server_pk = PublicKey::from_slice(&server_pk_bytes).unwrap();
+            let addr = "130.133.110.14:33445".parse().unwrap();
+            (addr, server_pk)
+        },
+        3 => {
+            // local C DHT node, TODO remove this case
+            let server_pk_bytes = FromHex::from_hex("C4B8D288C391704E3C8840A8A7C19B21D0B76CAF3B55341D37C5A9732887F879").unwrap();
+            let server_pk = PublicKey::from_slice(&server_pk_bytes).unwrap();
+            let addr = "0.0.0.0:33445".parse().unwrap();
+            (addr, server_pk)
+        }
+        _ => {
+            unreachable!()
+        }
+    };
+
     let client = TcpStream::connect(&addr, &handle)
-        .and_then(|socket| {
+        .and_then(move |socket| {
             make_client_handshake(socket, client_pk, client_sk, server_pk)
         })
         .and_then(|(socket, channel)| {
-            println!("Handshake complited");
+            debug!("Handshake complited");
+
             let secure_socket = socket.framed(codec::Codec::new(channel));
-            let (_to_server, _from_server) = secure_socket.split();
-            // use example https://github.com/jgallagher/tokio-chat-example/blob/master/tokio-chat-client/src/main.rs
+            let (to_server, from_server) = secure_socket.split();
+
+            let reader = from_server.for_each(move |packet| -> IoFuture<()> {
+                debug!("Got packet {:?}", packet);
+                // Simple pong responser
+                if let Packet::PingRequest(ping) = packet {
+                    Box::new(
+                        tx.clone().send(Packet::PongResponse(
+                            PongResponse { ping_id: ping.ping_id }
+                        ))
+                        .map(|_| () )
+                        .map_err(|_| Error::new(ErrorKind::Other, "Could not send pong") )
+                    )
+                } else {
+                    Box::new( future::ok(()) )
+                }
+            })
+            .then(|res| {
+                debug!("Reader ended with {:?}", res);
+                res
+            });
+
+            let writer = rx
+                .map_err(|()| unreachable!("rx can't fail"))
+                .fold(to_server, move |to_server, packet| {
+                    debug!("Send packet {:?}", packet);
+                    to_server.send(packet)
+                })
+                // drop to_client when rx stream is exhausted
+                .map(|_to_client| {
+                    debug!("Stream rx is exhausted");
+                    ()
+                })
+                .map_err(|err| {
+                    error!("Writer err: {}", err);
+                    err
+                });;
+
+            reader.select(writer).map(|_| ()).map_err(|(err, _select_next)| err)
+        })
+        .then(|res| {
+            debug!("client ended with {:?}", res);
             Ok(())
         });
 
-    core.run(client).unwrap();
+    Box::new(client)
+}
+
+#[allow(dead_code)]
+fn send_packets(tx: mpsc::Sender<Packet>) {
+    // Client friend constant PK for examples/tests
+    let friend_pk = PublicKey([15, 107, 126, 130, 81, 55, 154, 157,
+                            192, 117, 0, 225, 119, 43, 48, 117,
+                            84, 109, 112, 57, 243, 216, 4, 171,
+                            185, 111, 33, 146, 221, 31, 77, 118]);
+
+    let mut i = 0u64;
+    loop {
+        let sleep_duration = time::Duration::from_millis(1);
+        match tx.clone().send(Packet::RouteRequest(RouteRequest {pk: friend_pk } )).wait() {
+            Ok(_tx) => (),
+            Err(e) => {
+                error!("send_packets: {:?}", e);
+                break
+            },
+        };
+        if i % 10000 == 0 {
+            thread::sleep(sleep_duration);
+            println!("i = {}", i);
+        }
+        i = i + 1;
+
+    }
+    /*
+    let packets = vec![
+        Packet::RouteRequest(RouteRequest {pk: friend_pk } ),
+        Packet::RouteRequest(RouteRequest {pk: friend_pk } ),
+        Packet::RouteRequest(RouteRequest {pk: friend_pk } ),
+        Packet::RouteRequest(RouteRequest {pk: friend_pk } )
+    ];
+
+    let sleep_duration = time::Duration::from_millis(1500);
+    for packet in packets {
+        match tx.clone().send(packet).wait() {
+            Ok(_tx) => (),
+            Err(e) => {
+                error!("send_packets: {:?}", e);
+                break
+            },
+        };
+        thread::sleep(sleep_duration);
+    }
+    thread::sleep(sleep_duration);
+    */
+}
+
+fn main() {
+    env_logger::init().unwrap();
+
+    let (tx, rx) = mpsc::channel(1);
+
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+    let client = create_client(rx, tx.clone(), &handle);
+
+    // variant 1. send packets in the same thread, combine with select(...)
+    let packet_sender = future::loop_fn(tx.clone(), move |tx| {
+        // Client friend constant PK for examples/tests
+        let friend_pk = PublicKey([15, 107, 126, 130, 81, 55, 154, 157,
+                                192, 117, 0, 225, 119, 43, 48, 117,
+                                84, 109, 112, 57, 243, 216, 4, 171,
+                                185, 111, 33, 146, 221, 31, 77, 118]);
+
+        tx.send(Packet::RouteRequest(RouteRequest {pk: friend_pk } ))
+            .and_then(|tx| Ok(future::Loop::Continue(tx)) )
+            .or_else(|e| Ok(future::Loop::Break(e)) )
+    }).map(|_| ());
+    let client = client.select(packet_sender).map_err(|_| ());
+
+    // variant 2. send packets in a separate thread
+    //thread::spawn(move || send_packets(tx));
+
+    core.run( client ).unwrap();
 }

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -21,25 +21,32 @@
 
 extern crate tox;
 extern crate futures;
-extern crate bytes;
-extern crate nom;
 extern crate tokio_core;
 extern crate tokio_io;
+extern crate tokio_timer;
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
 
 use tox::toxcore::crypto_core::*;
 use tox::toxcore::tcp::make_server_handshake;
 use tox::toxcore::tcp::codec;
 use tox::toxcore::tcp::server::{Server, Client};
 
-use futures::{Sink, Stream, Future};
+use futures::prelude::*;
 use futures::sync::mpsc;
 
-use tokio_io::*;
+use tokio_io::AsyncRead;
 use tokio_core::reactor::Core;
 use tokio_core::net::TcpListener;
 
+use std::time;
+
 fn main() {
-    // Some constant keypair
+    env_logger::init().unwrap();
+    // Server constant PK for examples/tests
+    // Use `gen_keypair` to generate random keys
     let server_pk = PublicKey([177, 185, 54, 250, 10, 168, 174,
                             148, 0, 93, 99, 13, 131, 131, 239,
                             193, 129, 141, 80, 158, 50, 133, 100,
@@ -53,67 +60,74 @@ fn main() {
     let handle = core.handle();
     let listener = TcpListener::bind(&addr, &handle).unwrap();
 
-    println!("Listening on {} using PK {:?}", addr, &server_pk.0);
+    info!("Listening on addr={}, {:?}", addr, &server_pk);
 
     let server_inner = Server::new();
 
     // TODO move this processing future into a standalone library function
     let server = listener.incoming().for_each(|(socket, addr)| {
-        println!("A new client connected from {}", addr);
+        debug!("A new client connected from {}", addr);
 
         let server_inner_c = server_inner.clone();
         let register_client = make_server_handshake(socket, server_sk.clone())
             .map_err(|e| {
-                println!("handshake error: {}", e);
+                error!("handshake error: {}", e);
                 e
             })
             .and_then(move |(socket, channel, client_pk)| {
-                println!("Handshake for client {:?} complited", &client_pk);
+                debug!("Handshake for client {:?} complited", &client_pk);
                 let (tx, rx) = mpsc::unbounded();
                 server_inner_c.insert(Client::new(tx, &client_pk));
 
                 Ok((socket, channel, client_pk, rx))
             });
+
         let server_inner_c = server_inner.clone();
         let process_connection = register_client
             .and_then(move |(socket, channel, client_pk, rx)| {
+                let server_inner_c_c = server_inner_c.clone();
                 let secure_socket = socket.framed(codec::Codec::new(channel));
                 let (to_client, from_client) = secure_socket.split();
 
                 // reader = for each Packet from client process it
-                let server_inner_c_c = server_inner_c.clone();
                 let reader = from_client.for_each(move |packet| {
-                    println!("Handle {:?} => {:?}", client_pk, packet);
-                    server_inner_c_c.handle_packet(&client_pk, packet)
+                    debug!("Handle {:?} => {:?}", client_pk, packet);
+                    server_inner_c.handle_packet(&client_pk, packet)
                 });
 
+                let writer_timer = tokio_timer::wheel()
+                    .tick_duration(time::Duration::from_secs(1))
+                    .build()
+                ;
                 // writer = for each Packet from rx send it to client
                 let writer = rx
                     .map_err(|()| unreachable!("rx can't fail"))
                     .fold(to_client, move |to_client, packet| {
-                        println!("Send {:?} => {:?}", client_pk, packet);
-                        to_client.send(packet)
+                        debug!("Send {:?} => {:?}", client_pk, packet);
+                        let sending_future = to_client.send(packet);
+                        let duration = time::Duration::from_secs(30);
+                        let timeout = writer_timer.timeout(sending_future, duration);
+                        timeout
                     })
                     // drop to_client when rx stream is exhausted
                     .map(|_to_client| ());
 
                 // TODO ping request = each 30s send PingRequest to client
 
-                let server_inner_c_c = server_inner_c.clone();
                 reader.select(writer)
                     .map(|_| ())
                     .map_err(move |(err, _select_next)| {
-                        println!("Processing client {:?} ended with error: {:?}", &client_pk, err);
+                        error!("Processing client {:?} ended with error: {:?}", &client_pk, err);
                         err
                     })
                     .then(move |r_processing| {
-                        println!("shutdown PK {:?}", &client_pk);
+                        debug!("shutdown PK {:?}", &client_pk);
                         server_inner_c_c.shutdown_client(&client_pk)
                             .then(move |r_shutdown| r_processing.and(r_shutdown))
                     })
             });
         handle.spawn(process_connection.then(|r| {
-            println!("end of processing with result {:?}", r);
+            debug!("end of processing with result {:?}", r);
             Ok(())
         }));
 

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -69,7 +69,7 @@ fn main() {
             })
             .and_then(move |(socket, channel, client_pk)| {
                 println!("Handshake for client {:?} complited", &client_pk);
-                let (tx, rx) = mpsc::channel(8);
+                let (tx, rx) = mpsc::unbounded();
                 server_inner_c.insert(Client::new(tx, &client_pk));
 
                 Ok((socket, channel, client_pk, rx))

--- a/src/toxcore/tcp/codec.rs
+++ b/src/toxcore/tcp/codec.rs
@@ -69,8 +69,7 @@ impl Decoder for Codec {
             )?;
 
         // deserialize Packet
-        let local_stack = BytesMut::from(decrypted_data);
-        match Packet::from_bytes(&local_stack) {
+        match Packet::from_bytes(&decrypted_data) {
             IResult::Incomplete(_) => {
                 Err(Error::new(ErrorKind::Other,
                     "Packet should not be incomplete"))

--- a/src/toxcore/tcp/server/client.rs
+++ b/src/toxcore/tcp/server/client.rs
@@ -40,7 +40,7 @@ pub struct Client {
     /// PublicKey of the client.
     pk: PublicKey,
     /// The transmission end of a channel which is used to send values.
-    tx: mpsc::Sender<Packet>,
+    tx: mpsc::UnboundedSender<Packet>,
     /** links - a table of indexing links from this client to another
 
     A client requests to link him with another client by PK with RouteRequest.
@@ -59,7 +59,7 @@ pub struct Client {
 impl Client {
     /** Create new Client
     */
-    pub fn new(tx: mpsc::Sender<Packet>, pk: &PublicKey) -> Client {
+    pub fn new(tx: mpsc::UnboundedSender<Packet>, pk: &PublicKey) -> Client {
         Client {
             pk: *pk,
             tx: tx,

--- a/src/toxcore/tcp/server/server.rs
+++ b/src/toxcore/tcp/server/server.rs
@@ -38,9 +38,9 @@ use tokio_io::IoFuture;
 /** A `Server` is a structure that holds connected clients, manages their links and handles
 their responses. Notice that there is no actual network code here, the `Server` accepts packets
 by value from `Server::handle_packet`, sends packets back to clients via
-`futures::sync::mpsc::Sender<Packet>` channel. The outer code should manage how to handshake
+`futures::sync::mpsc::UnboundedSender<Packet>` channel. The outer code should manage how to handshake
 connections, get packets from clients, pass them into `Server::handle_packet`,
-create `mpsc` chanel, take packets from `futures::sync::mpsc::Receiver<Packet>` send them back
+create `mpsc` chanel, take packets from `futures::sync::mpsc::UnboundedReceiver<Packet>` send them back
 to clients via network.
 */
 #[derive(Clone)]
@@ -331,9 +331,9 @@ mod tests {
 
     /// A function that generates random keypair, creates mpsc channel
     ///  and inserts them as a mock Client into Server
-    fn add_random_client(server: &Server) -> (PublicKey, mpsc::Receiver<Packet>) {
+    fn add_random_client(server: &Server) -> (PublicKey, mpsc::UnboundedReceiver<Packet>) {
         let (client_pk, _) = gen_keypair();
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::unbounded();
         server.insert(Client::new(tx, &client_pk));
         (client_pk, rx)
     }
@@ -359,7 +359,7 @@ mod tests {
         ));
 
         // client 2 connects to the server
-        let (tx_2, rx_2) = mpsc::channel(1);
+        let (tx_2, rx_2) = mpsc::unbounded();
         server.insert(Client::new(tx_2, &client_pk_2));
 
         // emulate send RouteRequest from client_1 again


### PR DESCRIPTION
1) speedup codec
2) add timeouts to send packets from tcp relay
3) add example to send packets in tcp relay client

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zetok/tox/113)
<!-- Reviewable:end -->
